### PR TITLE
Add support for pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
         python3 -m pip install --no-binary ':all:' nose
         # work-around for <https://github.com/nose-devs/nose/issues/1116>:
         sed -i -e 's/ from unittest import _TextTestResult$/ from unittest import TextTestResult as _TextTestResult/' ${{env.pythonLocation}}/lib/python*/site-packages/nose/result.py
+        python3 -m pip install pytest
         python3 -m pip install polib
         python3 -m pip install rply
         python3 -m pip install pytz  # for private/update-timezones

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,14 @@ jobs:
         - python: '3.8'
           os: ubuntu-20.04
         - python: '3.9'
+          pytest: pytest==3.0
           os: ubuntu-20.04
         - python: '3.10'
+          pytest: pytest
           os: ubuntu-20.04
         - python: '3.11-dev'
           os: ubuntu-22.04
+          pytest: pytest
     runs-on: ${{matrix.os}}
     steps:
     - uses: actions/checkout@v2
@@ -33,13 +36,14 @@ jobs:
         python3 -m pip install rply
     - name: run tests
       run: |
-        # work-around for <https://github.com/nose-devs/nose/issues/1115>:
-        pip install 'setuptools<58'
-        # work-around for <https://github.com/nose-devs/nose/issues/1099>:
-        python3 -m pip install --no-binary ':all:' nose
-        # work-around for <https://github.com/nose-devs/nose/issues/1116>:
-        sed -i -e 's/ from unittest import _TextTestResult$/ from unittest import TextTestResult as _TextTestResult/' ${{env.pythonLocation}}/lib/python*/site-packages/nose/result.py
+        python3 -m pip install nose
         tests/run-tests -v
+      if: ${{! matrix.pytest}}
+    - name: run tests
+      run: |
+        python3 -m pip install ${{matrix.pytest}}
+        python3 -m pytest -v
+      if: ${{matrix.pytest}}
     - name: check docs
       run: |
         dpkg-parsechangelog -ldoc/changelog --all 2>&1 >/dev/null | { ! grep .; }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py pytest.py
+python_classes = test_*
+python_functions = test test_*

--- a/tests/blackbox_tests/__init__.py
+++ b/tests/blackbox_tests/__init__.py
@@ -31,8 +31,6 @@ import sys
 import traceback
 import unittest
 
-import nose.plugins
-
 from .. import tools
 
 here = os.path.dirname(__file__)
@@ -135,26 +133,32 @@ def get_signal_name(n):
 test_file_extensions = ('.mo', '.po', '.pot', '.pop')
 # .pop is a special extension to trigger unknown-file-type
 
-class Plugin(nose.plugins.Plugin):
+def nose_plugin():
 
-    name = 'po-plugin'
-    enabled = True
+    import nose.plugins  # pylint: disable=import-outside-toplevel
 
-    def options(self, parser, env):
-        pass
+    class Plugin(nose.plugins.Plugin):
 
-    def wantFile(self, path):
-        if path.endswith(test_file_extensions):
-            if path.startswith(os.path.join(os.path.abspath(here), '')):
-                return True
+        name = 'po-plugin'
+        enabled = True
 
-    def loadTestsFromFile(self, path):
-        if self.wantFile(path):
-            yield TestCase(path)
+        def options(self, parser, env):
+            pass
 
-    def wantFunction(self, func):
-        if getattr(func, 'redundant', False):
-            return False
+        def wantFile(self, path):
+            if path.endswith(test_file_extensions):
+                if path.startswith(os.path.join(os.path.abspath(here), '')):
+                    return True
+
+        def loadTestsFromFile(self, path):
+            if self.wantFile(path):
+                yield TestCase(path)
+
+        def wantFunction(self, func):
+            if getattr(func, 'redundant', False):
+                return False
+
+    return Plugin()
 
 class TestCase(unittest.TestCase):
 

--- a/tests/blackbox_tests/__init__.py
+++ b/tests/blackbox_tests/__init__.py
@@ -369,6 +369,7 @@ def _get_test_filenames():
                 continue
             yield os.path.join(root, filename)
 
+@tools.collect_yielded
 def test_file():
     for filename in _get_test_filenames():
         path = os.path.relpath(filename, start=here)

--- a/tests/blackbox_tests/__init__.py
+++ b/tests/blackbox_tests/__init__.py
@@ -31,7 +31,6 @@ import sys
 import traceback
 import unittest
 
-import nose
 import nose.plugins
 
 from .. import tools
@@ -283,7 +282,7 @@ def assert_emit_tags(path, etags, *, options=()):
     expected_failure = os.path.basename(path).startswith('xfail-')
     if stdout != etags:
         if expected_failure:
-            raise nose.SkipTest('expected failure')
+            raise unittest.SkipTest('expected failure')
         str_etags = [str(x) for x in etags]
         message = ['Tags differ:', '']
         diff = list(
@@ -386,7 +385,7 @@ E: os-error Permission denied
 ''')
 def test_os_error_permission_denied():
     if os.getuid() == 0:
-        raise nose.SkipTest('this test must not be run as root')
+        raise unittest.SkipTest('this test must not be run as root')
     with tools.temporary_directory() as tmpdir:
         path = os.path.join(tmpdir, 'denied.po')
         with open(path, 'wb'):

--- a/tests/blackbox_tests/pytest.py
+++ b/tests/blackbox_tests/pytest.py
@@ -1,0 +1,36 @@
+# Copyright © 2021 Jakub Wilk <jwilk@jwilk.net>
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the “Software”), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# pytest wouldn't look for tests in the __init__.py,
+# so let's expose the tests through a separate module.
+
+from . import (
+    test_file,
+    test_os_error_no_such_file,
+    test_os_error_permission_denied,
+)
+
+__all__ = [
+    'test_file',
+    'test_os_error_no_such_file',
+    'test_os_error_permission_denied',
+]
+
+# vim:ts=4 sts=4 sw=4 et

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+# encoding=UTF-8
+
+# Copyright © 2021 Stuart Prescott <stuart@debian.org>
+# Copyright © 2021 Jakub Wilk <jwilk@jwilk.net>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the “Software”), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+
+import tests.tools
+
+def pytest_sessionstart(session):
+    envvar = 'XDG_CACHE_HOME'
+    old_xdg_cache_home = os.environ.get(envvar, None)
+    xdg_temp_dir = tests.tools.temporary_directory()  # pylint: disable=consider-using-with
+    os.environ[envvar] = xdg_temp_dir.name
+    def cleanup():
+        xdg_temp_dir.cleanup()
+        if old_xdg_cache_home is None:
+            del os.environ[envvar]
+        else:
+            os.environ[envvar] = old_xdg_cache_home
+    session.config.add_cleanup(cleanup)
+
+# vim:ts=4 sts=4 sw=4 et

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 # encoding=UTF-8
 
 # Copyright © 2021 Stuart Prescott <stuart@debian.org>
-# Copyright © 2021 Jakub Wilk <jwilk@jwilk.net>
+# Copyright © 2021-2022 Jakub Wilk <jwilk@jwilk.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the “Software”), to deal

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,7 @@ def _collect_yielded(generator):
                     assert getattr(owner, aname, None) is None
                     setattr(owner, aname, _make_method(fn, args))
         return YieldTestDescriptor()
-    elif genargs == []:
+    elif genargs == []:  # pylint: disable=use-implicit-booleaness-not-comparison
         class Test():
             pass
         try:

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -33,6 +33,6 @@ from tests import blackbox_tests
 if __name__ == '__main__':
     with tempfile.TemporaryDirectory(prefix='i18nspector.tests.') as tmpdir:
         os.environ['XDG_CACHE_HOME'] = tmpdir
-        nose.main(addplugins=[blackbox_tests.Plugin()])
+        nose.main(addplugins=[blackbox_tests.nose_plugin()])
 
 # vim:ts=4 sts=4 sw=4 et

--- a/tests/run-tests
+++ b/tests/run-tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright © 2013-2016 Jakub Wilk <jwilk@jwilk.net>
+# Copyright © 2013-2021 Jakub Wilk <jwilk@jwilk.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the “Software”), to deal

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -21,11 +21,11 @@
 import os
 import re
 
-from nose.tools import (
+import lib.tags
+
+from .tools import (
     assert_not_equal,
 )
-
-import lib.tags
 
 here = os.path.dirname(__file__)
 docdir = os.path.join(here, os.pardir, 'doc')

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -25,6 +25,7 @@ import lib.tags
 
 from .tools import (
     assert_not_equal,
+    collect_yielded,
 )
 
 here = os.path.dirname(__file__)
@@ -52,6 +53,7 @@ rename_re = re.compile(
     r'([\w-]+) [(]from ([\w-]+)[)]'
 )
 
+@collect_yielded
 def test_tags():
     path = os.path.join(docdir, 'changelog')
     with open(path, 'rt', encoding='UTF-8') as file:

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -18,14 +18,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from nose.tools import (
+import lib.domains as M
+
+from .tools import (
     assert_false,
     assert_is,
     assert_raises,
     assert_true,
 )
-
-import lib.domains as M
 
 class test_special_domains:
 

--- a/tests/test_encodings.py
+++ b/tests/test_encodings.py
@@ -20,8 +20,8 @@
 
 import curses.ascii
 import sys
+import unittest
 
-import nose
 from nose.tools import (
     assert_equal,
     assert_false,
@@ -164,7 +164,7 @@ class test_extra_encoding:
         except LookupError:
             pass
         else:
-            raise nose.SkipTest(
+            raise unittest.SkipTest(
                 'python{ver[0]}.{ver[1]} supports the {enc} encoding'.format(
                     ver=sys.version_info,
                     enc=encoding
@@ -193,7 +193,7 @@ class test_extra_encoding:
         except LookupError:
             pass
         else:
-            raise nose.SkipTest(
+            raise unittest.SkipTest(
                 'python{ver[0]}.{ver[1]} supports the {enc} encoding'.format(
                     ver=sys.version_info,
                     enc=encoding

--- a/tests/test_encodings.py
+++ b/tests/test_encodings.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2017 Jakub Wilk <jwilk@jwilk.net>
+# Copyright © 2012-2021 Jakub Wilk <jwilk@jwilk.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the “Software”), to deal

--- a/tests/test_encodings.py
+++ b/tests/test_encodings.py
@@ -33,6 +33,7 @@ from .tools import (
     assert_not_in,
     assert_raises,
     assert_true,
+    collect_yielded,
 )
 
 class test_is_portable_encoding:
@@ -58,6 +59,7 @@ class test_propose_portable_encoding:
         portable_encoding = E.propose_portable_encoding(encoding)
         assert_equal(portable_encoding, encoding)
 
+    @collect_yielded
     def test_found(self):
         def t(encoding, expected_portable_encoding):
             portable_encoding = E.propose_portable_encoding(encoding)
@@ -72,6 +74,7 @@ class test_propose_portable_encoding:
 
 class test_ascii_compatibility:
 
+    @collect_yielded
     def test_portable(self):
         def t(encoding):
             assert_true(E.is_ascii_compatible_encoding(encoding))
@@ -79,6 +82,7 @@ class test_ascii_compatibility:
         for encoding in E.get_portable_encodings():
             yield t, encoding
 
+    @collect_yielded
     def test_incompatible(self):
         def t(encoding):
             assert_false(E.is_ascii_compatible_encoding(encoding))
@@ -91,6 +95,7 @@ class test_ascii_compatibility:
         with assert_raises(E.EncodingLookupError):
             E.is_ascii_compatible_encoding(encoding, missing_ok=False)
 
+    @collect_yielded
     def test_non_text(self):
         t = self._test_missing
         yield t, 'base64_codec'

--- a/tests/test_encodings.py
+++ b/tests/test_encodings.py
@@ -22,7 +22,11 @@ import curses.ascii
 import sys
 import unittest
 
-from nose.tools import (
+import lib.encodings as E
+
+from . import tools
+
+from .tools import (
     assert_equal,
     assert_false,
     assert_is_none,
@@ -30,10 +34,6 @@ from nose.tools import (
     assert_raises,
     assert_true,
 )
-
-import lib.encodings as E
-
-from . import tools
 
 class test_is_portable_encoding:
 

--- a/tests/test_gettext.py
+++ b/tests/test_gettext.py
@@ -20,7 +20,9 @@
 
 import datetime
 
-from nose.tools import (
+import lib.gettext as M
+
+from .tools import (
     assert_equal,
     assert_false,
     assert_is_instance,
@@ -30,8 +32,6 @@ from nose.tools import (
     assert_raises,
     assert_true,
 )
-
-import lib.gettext as M
 
 class test_header_fields:
 

--- a/tests/test_iconv.py
+++ b/tests/test_iconv.py
@@ -1,4 +1,4 @@
-# Copyright © 2013-2019 Jakub Wilk <jwilk@jwilk.net>
+# Copyright © 2013-2021 Jakub Wilk <jwilk@jwilk.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the “Software”), to deal

--- a/tests/test_iconv.py
+++ b/tests/test_iconv.py
@@ -18,12 +18,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from nose.tools import (
+import lib.iconv as M
+
+from .tools import (
     assert_equal,
     assert_raises,
 )
-
-import lib.iconv as M
 
 class _test:
     u = None

--- a/tests/test_ling.py
+++ b/tests/test_ling.py
@@ -18,7 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import nose
+import unittest
+
 from nose.tools import (
     assert_equal,
     assert_false,
@@ -419,16 +420,16 @@ def test_glibc_supported():
         except L.FixingLanguageCodesFailed:
             # FIXME: some ISO-639-3 codes are not recognized yet
             if len(l.split('_')[0]) == 3:
-                raise nose.SkipTest('expected failure')
+                raise unittest.SkipTest('expected failure')
             reason = locales_to_skip.get(l)
             if reason is not None:
-                raise nose.SkipTest(reason)
+                raise unittest.SkipTest(reason)
             raise
         assert_equal(str(lang), l)
     try:
         file = open('/usr/share/i18n/SUPPORTED', encoding='ASCII')  # pylint: disable=consider-using-with
     except OSError as exc:
-        raise nose.SkipTest(exc)
+        raise unittest.SkipTest(exc)
     locales = set()
     with file:
         for line in file:
@@ -466,7 +467,7 @@ def test_poedit():
         poedit_ll = L.parse_language(poedit_ll)
         with assert_raises(LookupError):
             L.get_language_for_name(name)
-        raise nose.SkipTest('expected failure')
+        raise unittest.SkipTest('expected failure')
     yield t, 'Abkhazian', 'ab'
     yield t, 'Afar', 'aa'
     yield t, 'Afrikaans', 'af'

--- a/tests/test_ling.py
+++ b/tests/test_ling.py
@@ -36,6 +36,7 @@ from .tools import (
     assert_not_in,
     assert_raises,
     assert_true,
+    collect_yielded,
 )
 
 L = lib.ling
@@ -253,6 +254,7 @@ class test_get_primary_languages:
         langs = L.get_primary_languages()
         assert_not_in('ry', langs)
 
+    @collect_yielded
     def test_iso_639(self):
         def t(lang_str):
             lang = L.parse_language(lang_str)
@@ -412,6 +414,7 @@ class test_unrepresentable_characters:
         result = lang.get_unrepresentable_characters(encoding)
         assert_not_equal(result, [])
 
+@collect_yielded
 def test_glibc_supported():
     def t(l):
         lang = L.parse_language(l)
@@ -455,6 +458,7 @@ def test_glibc_supported():
     for l in sorted(locales):
         yield t, l
 
+@collect_yielded
 def test_poedit():
     # https://github.com/vslavik/poedit/blob/v1.8.1-oss/src/language_impl_legacy.h
     # There won't be any new names in this table,

--- a/tests/test_ling.py
+++ b/tests/test_ling.py
@@ -20,7 +20,12 @@
 
 import unittest
 
-from nose.tools import (
+import lib.encodings
+import lib.ling
+
+from . import tools
+
+from .tools import (
     assert_equal,
     assert_false,
     assert_in,
@@ -32,11 +37,6 @@ from nose.tools import (
     assert_raises,
     assert_true,
 )
-
-import lib.encodings
-import lib.ling
-
-from . import tools
 
 L = lib.ling
 T = lib.ling.Language

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2017 Jakub Wilk <jwilk@jwilk.net>
+# Copyright © 2012-2021 Jakub Wilk <jwilk@jwilk.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the “Software”), to deal

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -24,7 +24,9 @@ import stat
 import tempfile
 import time
 
-from nose.tools import (
+import lib.misc as M
+
+from .tools import (
     assert_almost_equal,
     assert_equal,
     assert_is_instance,
@@ -32,8 +34,6 @@ from nose.tools import (
     assert_raises,
     assert_true,
 )
-
-import lib.misc as M
 
 from . import tools
 

--- a/tests/test_moparser.py
+++ b/tests/test_moparser.py
@@ -20,12 +20,12 @@
 
 import random
 
-from nose.tools import (
+import lib.moparser as M
+
+from .tools import (
     assert_equal,
     assert_raises,
 )
-
-import lib.moparser as M
 
 from . import tools
 

--- a/tests/test_moparser.py
+++ b/tests/test_moparser.py
@@ -1,4 +1,4 @@
-# Copyright © 2014-2017 Jakub Wilk <jwilk@jwilk.net>
+# Copyright © 2014-2021 Jakub Wilk <jwilk@jwilk.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the “Software”), to deal

--- a/tests/test_polib4us.py
+++ b/tests/test_polib4us.py
@@ -1,4 +1,4 @@
-# Copyright © 2013-2017 Jakub Wilk <jwilk@jwilk.net>
+# Copyright © 2013-2021 Jakub Wilk <jwilk@jwilk.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the “Software”), to deal

--- a/tests/test_polib4us.py
+++ b/tests/test_polib4us.py
@@ -20,12 +20,12 @@
 
 import polib
 
-from nose.tools import (
+import lib.polib4us as M
+
+from .tools import (
     assert_list_equal,
     assert_true,
 )
-
-import lib.polib4us as M
 
 from . import tools
 

--- a/tests/test_strformat_c.py
+++ b/tests/test_strformat_c.py
@@ -31,6 +31,7 @@ from .tools import (
     assert_is_instance,
     assert_raises,
     assert_sequence_equal,
+    collect_yielded,
 )
 
 def test_INT_MAX():
@@ -99,6 +100,7 @@ class test_types:
             assert_is_instance(warning, warn_type)
         assert_equal(conv.integer, integer)
 
+    @collect_yielded
     def test_integer(self):
         def t(s, tp, warn_type=None):
             if s[-1] == 'n':
@@ -132,6 +134,7 @@ class test_types:
             yield t('%Z' + c, 'size_t', M.NonPortableConversion)
             yield t('%t' + c, '[unsigned ptrdiff_t]')
 
+    @collect_yielded
     def test_double(self):
         t = self.t
         for c in 'aefgAEFG':
@@ -139,6 +142,7 @@ class test_types:
             yield t, ('%l' + c), 'double', M.NonPortableConversion
             yield t, ('%L' + c), 'long double'
 
+    @collect_yielded
     def test_char(self):
         t = self.t
         yield t, '%c', 'char'
@@ -148,12 +152,14 @@ class test_types:
         yield t, '%ls', 'const wchar_t *'
         yield t, '%S', 'const wchar_t *', M.NonPortableConversion
 
+    @collect_yielded
     def test_void(self):
         t = self.t
         yield t, '%p', 'void *'
         yield t, '%m', 'void'
         yield t, '%%', 'void'
 
+    @collect_yielded
     def test_c99_macros(self):
         # pylint: disable=undefined-loop-variable
         def _t(s, tp):
@@ -181,6 +187,7 @@ class test_invalid_length:
 
     _lengths = ['hh', 'h', 'l', 'll', 'q', 'j', 'z', 't', 'L']
 
+    @collect_yielded
     def test_double(self):
         t = self.t
         for c in 'aefgAEFG':
@@ -189,6 +196,7 @@ class test_invalid_length:
                     continue
                 yield t, ('%' + l + c)
 
+    @collect_yielded
     def test_char(self):
         t = self.t
         for c in 'cs':
@@ -197,6 +205,7 @@ class test_invalid_length:
                     yield t, '%' + l + c
                 yield t, ('%' + l + c.upper())
 
+    @collect_yielded
     def test_void(self):
         t = self.t
         for c in 'pm%':
@@ -277,18 +286,22 @@ class test_expected_flag:
         fmt = M.FormatString(s)
         assert_equal(len(fmt), 1)
 
+    @collect_yielded
     def test_hash(self):
         for c in 'oxXaAeEfFgG':
             yield self.t, ('%#' + c)
 
+    @collect_yielded
     def test_zero(self):
         for c in 'diouxXaAeEfFgG':
             yield self.t, ('%0' + c)
 
+    @collect_yielded
     def test_apos(self):
         for c in 'diufFgG':
             yield self.t, ("%'" + c)
 
+    @collect_yielded
     def test_other(self):
         for flag in '- +I':
             for c in 'diouxXaAeEfFgGcCsSpm':
@@ -300,18 +313,22 @@ class test_unexpected_flag:
         with assert_raises(M.FlagError):
             M.FormatString(s)
 
+    @collect_yielded
     def test_hash(self):
         for c in 'dicCsSnpm%':
             yield self.t, ('%#' + c)
 
+    @collect_yielded
     def test_zero(self):
         for c in 'cCsSnpm%':
             yield self.t, ('%0' + c)
 
+    @collect_yielded
     def test_apos(self):
         for c in 'oxXaAeEcCsSnpm%':
             yield self.t, ("%'" + c)
 
+    @collect_yielded
     def test_other(self):
         for c in '%n':
             for flag in '- +I':
@@ -319,6 +336,7 @@ class test_unexpected_flag:
 
 class test_width:
 
+    @collect_yielded
     def test_ok(self):
         def t(s):
             fmt = M.FormatString(s)
@@ -389,6 +407,7 @@ class test_width:
 
 class test_precision:
 
+    @collect_yielded
     def test_ok(self):
         def t(s):
             fmt = M.FormatString(s)
@@ -396,6 +415,7 @@ class test_precision:
         for c in 'diouxXaAeEfFgGsS':
             yield t, ('%.1' + c)
 
+    @collect_yielded
     def test_redundant_0(self):
         def t(s):
             fmt = M.FormatString(s)
@@ -405,6 +425,7 @@ class test_precision:
         for c in 'diouxX':
             yield t, ('%0.1' + c)
 
+    @collect_yielded
     def test_non_redundant_0(self):
         def t(s):
             fmt = M.FormatString(s)
@@ -413,6 +434,7 @@ class test_precision:
         for c in 'aAeEfFgG':
             yield t, ('%0.1' + c)
 
+    @collect_yielded
     def test_unexpected(self):
         def t(s):
             with assert_raises(M.PrecisionError):

--- a/tests/test_strformat_c.py
+++ b/tests/test_strformat_c.py
@@ -23,15 +23,15 @@ import struct
 import sys
 import unittest.mock
 
-from nose.tools import (
+import lib.strformat.c as M
+
+from .tools import (
     assert_equal,
     assert_greater,
     assert_is_instance,
     assert_raises,
     assert_sequence_equal,
 )
-
-import lib.strformat.c as M
 
 def test_INT_MAX():
     struct.pack('=i', M.INT_MAX)

--- a/tests/test_strformat_c.py
+++ b/tests/test_strformat_c.py
@@ -23,7 +23,6 @@ import struct
 import sys
 import unittest.mock
 
-import nose
 from nose.tools import (
     assert_equal,
     assert_greater,
@@ -54,7 +53,7 @@ def test_NL_ARGMAX():
             os.sysconf('SC_NL_ARGMAX')
         )
     else:
-        raise nose.SkipTest('Test specific to Linux with glibc')
+        raise unittest.SkipTest('Test specific to Linux with glibc')
 
 small_NL_ARGMAX = unittest.mock.patch('lib.strformat.c.NL_ARGMAX', 42)
 # Setting NL_ARGMAX to a small number makes the *_index_out_of_range() tests

--- a/tests/test_strformat_perlbrace.py
+++ b/tests/test_strformat_perlbrace.py
@@ -1,4 +1,4 @@
-# Copyright © 2016-2020 Jakub Wilk <jwilk@jwilk.net>
+# Copyright © 2016-2021 Jakub Wilk <jwilk@jwilk.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the “Software”), to deal

--- a/tests/test_strformat_perlbrace.py
+++ b/tests/test_strformat_perlbrace.py
@@ -18,12 +18,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from nose.tools import (
+import lib.strformat.perlbrace as M
+
+from .tools import (
     assert_equal,
     assert_raises,
 )
-
-import lib.strformat.perlbrace as M
 
 def test_lone_lcb():
     with assert_raises(M.Error):

--- a/tests/test_strformat_pybrace.py
+++ b/tests/test_strformat_pybrace.py
@@ -1,4 +1,4 @@
-# Copyright © 2016-2018 Jakub Wilk <jwilk@jwilk.net>
+# Copyright © 2016-2021 Jakub Wilk <jwilk@jwilk.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the “Software”), to deal

--- a/tests/test_strformat_pybrace.py
+++ b/tests/test_strformat_pybrace.py
@@ -21,14 +21,14 @@
 import struct
 import unittest.mock
 
-from nose.tools import (
+import lib.strformat.pybrace as M
+
+from .tools import (
     assert_equal,
     assert_is,
     assert_is_instance,
     assert_raises,
 )
-
-import lib.strformat.pybrace as M
 
 def test_SSIZE_MAX():
     struct.pack('=i', M.SSIZE_MAX)

--- a/tests/test_strformat_python.py
+++ b/tests/test_strformat_python.py
@@ -28,6 +28,7 @@ from .tools import (
     assert_is_instance,
     assert_raises,
     assert_sequence_equal,
+    collect_yielded,
 )
 
 def test_SSIZE_MAX():
@@ -97,30 +98,36 @@ class test_types:
             [warning] = fmt.warnings
             assert_is_instance(warning, warn_type)
 
+    @collect_yielded
     def test_integer(self):
         t = self.t
         for c in 'oxXdi':
             yield t, '%' + c, 'int'
         yield t, '%u', 'int', M.ObsoleteConversion
 
+    @collect_yielded
     def test_float(self):
         t = self.t
         for c in 'eEfFgG':
             yield t, '%' + c, 'float'
 
+    @collect_yielded
     def test_str(self):
         t = self.t
         yield t, '%c', 'chr'
         yield t, '%s', 'str'
 
+    @collect_yielded
     def test_repr(self):
         t = self.t
         for c in 'ra':
             yield t, '%' + c, 'object'
 
+    @collect_yielded
     def test_void(self):
         yield self.t, '%%', 'None'
 
+@collect_yielded
 def test_length():
     def t(l):
         fmt = M.FormatString('%' + l + 'd')
@@ -160,6 +167,7 @@ class test_multiple_flags:
     def test_plus_space(self):
         self.t('%+ d')
 
+@collect_yielded
 def test_single_flag():
 
     def t(s, expected):
@@ -179,6 +187,7 @@ def test_single_flag():
 
 class test_width:
 
+    @collect_yielded
     def test_ok(self):
         def t(s):
             fmt = M.FormatString(s)
@@ -212,6 +221,7 @@ class test_width:
 
 class test_precision:
 
+    @collect_yielded
     def test_ok(self):
         def t(s):
             fmt = M.FormatString(s)
@@ -219,6 +229,7 @@ class test_precision:
         for c in 'dioxXeEfFgGrsa':
             yield t, ('%.1' + c)
 
+    @collect_yielded
     def test_redundant_0(self):
         def t(s):
             fmt = M.FormatString(s)
@@ -228,6 +239,7 @@ class test_precision:
         for c in 'dioxX':
             yield t, ('%0.1' + c)
 
+    @collect_yielded
     def test_non_redundant_0(self):
         def t(s):
             fmt = M.FormatString(s)
@@ -236,6 +248,7 @@ class test_precision:
         for c in 'eEfFgG':
             yield t, ('%0.1' + c)
 
+    @collect_yielded
     def test_unexpected(self):
         def t(s):
             fmt = M.FormatString(s)

--- a/tests/test_strformat_python.py
+++ b/tests/test_strformat_python.py
@@ -20,15 +20,15 @@
 
 import struct
 
-from nose.tools import (
+import lib.strformat.python as M
+
+from .tools import (
     assert_equal,
     assert_greater,
     assert_is_instance,
     assert_raises,
     assert_sequence_equal,
 )
-
-import lib.strformat.python as M
 
 def test_SSIZE_MAX():
     struct.pack('=i', M.SSIZE_MAX)

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -24,16 +24,16 @@ import inspect
 import operator
 import pkgutil
 
-from nose.tools import (
+import lib.check
+import lib.tags as M
+
+from .tools import (
     assert_equal,
     assert_false,
     assert_is_instance,
     assert_raises,
     assert_true,
 )
-
-import lib.check
-import lib.tags as M
 
 class test_escape:
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -33,6 +33,7 @@ from .tools import (
     assert_is_instance,
     assert_raises,
     assert_true,
+    collect_yielded,
 )
 
 class test_escape:
@@ -74,6 +75,7 @@ def ast_to_tagnames(node):
     if ok:
         yield node.args[0].s
 
+@collect_yielded
 def test_consistency():
     source_tagnames = set()
     def visit_mod(modname):

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2018 Jakub Wilk <jwilk@jwilk.net>
+# Copyright © 2012-2021 Jakub Wilk <jwilk@jwilk.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the “Software”), to deal

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -23,11 +23,11 @@ import os
 import pty
 import sys
 
-from nose.tools import (
+import lib.terminal as T
+
+from .tools import (
     assert_equal,
 )
-
-import lib.terminal as T
 
 from . import tools
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2018 Jakub Wilk <jwilk@jwilk.net>
+# Copyright © 2012-2021 Jakub Wilk <jwilk@jwilk.net>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the “Software”), to deal

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -20,11 +20,11 @@
 
 import os
 
-from nose.tools import (
+from lib.cli import __version__
+
+from .tools import (
     assert_equal,
 )
-
-from lib.cli import __version__
 
 here = os.path.dirname(__file__)
 docdir = os.path.join(here, os.pardir, 'doc')

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -21,13 +21,13 @@
 import re
 import xml.etree.ElementTree as etree
 
-from nose.tools import (
+import lib.xml as M
+
+from .tools import (
     assert_is_none,
     assert_is_not_none,
     assert_raises,
 )
-
-import lib.xml as M
 
 class test_well_formed:
 

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -23,8 +23,7 @@ import os
 import sys
 import tempfile
 import traceback
-
-import nose
+import unittest
 
 temporary_file = functools.partial(
     tempfile.NamedTemporaryFile,
@@ -66,7 +65,7 @@ def fork_isolation(f):
             os.close(readfd)
             try:
                 f(*args, **kwargs)
-            except nose.SkipTest as exc:
+            except unittest.SkipTest as exc:
                 s = str(exc).encode('UTF-8')
                 with os.fdopen(writefd, 'wb') as fp:
                     fp.write(s)
@@ -90,7 +89,7 @@ def fork_isolation(f):
             if status == (EXIT_EXCEPTION << 8):
                 raise IsolatedException() from Exception('\n\n' + msg)
             elif status == (EXIT_SKIP_TEST << 8):
-                raise nose.SkipTest(msg)
+                raise unittest.SkipTest(msg)
             elif status == 0 and msg == '':
                 pass
             else:

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -25,24 +25,26 @@ import tempfile
 import traceback
 import unittest
 
-from nose.tools import (  # pylint: disable=unused-import
-    assert_almost_equal,
-    assert_equal,
-    assert_false,
-    assert_greater,
-    assert_in,
-    assert_is,
-    assert_is_instance,
-    assert_is_none,
-    assert_is_not_none,
-    assert_less,
-    assert_list_equal,
-    assert_not_equal,
-    assert_not_in,
-    assert_raises,
-    assert_sequence_equal,
-    assert_true,
-)
+tc = unittest.TestCase('__hash__')
+
+assert_almost_equal = tc.assertAlmostEqual
+assert_equal = tc.assertEqual
+assert_false = tc.assertFalse
+assert_greater = tc.assertGreater
+assert_in = tc.assertIn
+assert_is = tc.assertIs
+assert_is_instance = tc.assertIsInstance
+assert_is_none = tc.assertIsNone
+assert_is_not_none = tc.assertIsNotNone
+assert_less = tc.assertLess
+assert_list_equal = tc.assertListEqual
+assert_not_equal = tc.assertNotEqual
+assert_not_in = tc.assertNotIn
+assert_raises = tc.assertRaises
+assert_sequence_equal = tc.assertSequenceEqual
+assert_true = tc.assertTrue
+
+del tc
 
 temporary_file = functools.partial(
     tempfile.NamedTemporaryFile,

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -25,6 +25,25 @@ import tempfile
 import traceback
 import unittest
 
+from nose.tools import (  # pylint: disable=unused-import
+    assert_almost_equal,
+    assert_equal,
+    assert_false,
+    assert_greater,
+    assert_in,
+    assert_is,
+    assert_is_instance,
+    assert_is_none,
+    assert_is_not_none,
+    assert_less,
+    assert_list_equal,
+    assert_not_equal,
+    assert_not_in,
+    assert_raises,
+    assert_sequence_equal,
+    assert_true,
+)
+
 temporary_file = functools.partial(
     tempfile.NamedTemporaryFile,
     prefix='i18nspector.tests.',

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -46,6 +46,13 @@ assert_true = tc.assertTrue
 
 del tc
 
+def _collect_yielded(generator):
+    # Convert test generator to something the test harness understands.
+    # For nose, we don't need to do anything.
+    # For pytest, see the tests.conftest module.
+    return generator
+collect_yielded = _collect_yielded
+
 temporary_file = functools.partial(
     tempfile.NamedTemporaryFile,
     prefix='i18nspector.tests.',

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -72,8 +72,8 @@ def fork_isolation(f):
     EXIT_SKIP_TEST = 102
 
     exit = os._exit  # pylint: disable=redefined-builtin,protected-access
-    # sys.exit() can't be used here, because nose catches all exceptions,
-    # including SystemExit
+    # sys.exit() can't be used here, because the test harness catches
+    # all exceptions, including SystemExit
 
     # pylint:disable=consider-using-sys-exit
 


### PR DESCRIPTION
Fixes #7. Slimmer alternative to @llimeht's #8.
Cc: @s-t-e-v-e-n-k

This adds support for pytest, while retaining the possibility of using nose.

There's no equivalent for the PO file plugin yet, i.e. this doesn't work:

```console
$ python3 -m pytest "tests/blackbox_tests/okay.po"

```
(I might steal the code for that from #8 later on.)

But running all tests works just fine, which should be good enough for distro maintainers.

And if you really need to run such a single test, you can do:
```console
$ python3 -m pytest "tests/blackbox_tests/pytest.py::test_file::test['okay.po']"

```